### PR TITLE
Arm64 images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Format repo slug
         uses: actions/github-script@v8
         id: repo_slug
@@ -87,6 +90,7 @@ jobs:
           labels: ${{ steps.image_with_tags.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
### Description of the change

GHA WFs will build and push both amd64 and arm64 images to ghcr. Currently only amd64 images are produced.

Example of a passing workflow: [here](https://github.com/nikolayrk/containers/actions/runs/18435186750/job/52527712253)

### Benefits

Arm64 users can make use of these images, as they could the old Bitnami ones.

### Possible drawbacks

I haven't checked or tested whether all images work under arm64. I've only tested [Redis](https://github.com/nikolayrk/containers/pkgs/container/containers%2Fredis/541646460?tag=8.2.2).

### Applicable issues

N/A

### Additional information

N/A
